### PR TITLE
Add missing version of build-helper-maven-plugin

### DIFF
--- a/src/main/resources/templates/pom/SingleModule.ftl
+++ b/src/main/resources/templates/pom/SingleModule.ftl
@@ -192,6 +192,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>


### PR DESCRIPTION
Fixes warnings and avoids compatibility problems